### PR TITLE
Refactor header expectations to match what comes from postman request

### DIFF
--- a/app/controllers/api/v1/party/players_controller.rb
+++ b/app/controllers/api/v1/party/players_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::Party::PlayersController < ApplicationController
       render json: { "error": "player_id provided was not found"}, status: 400
     else
       # Database Action
-      party = Party.create!(party_params) unless party = Party.find_by(user_id: party_params[:user_id])
+      party = ::Party.create!(party_params) unless party = ::Party.find_by(user_id: party_params[:user_id])
       PartyPlayer.create!(party_player_params) unless PartyPlayer.where(party_id: party.id, player_id: params[:player_id]).length != 0
       # Responds with success even if no actions taken...?
       render json: PartyPlayerSerializer.player_party_create_response(party.players, party, params[:user_id]), status: 200

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::API
-  def validate_fe
-    if request.headers[:be_auth_key] != ENV['be_auth_key']
+  def validate_fe  
+    if request.headers['HTTP_BE_AUTH_KEY'] != ENV['be_auth_key']
       render json: { "error": "bad authentication key" }, status: 401
     end
   end

--- a/spec/requests/api/v1/parties/create_spec.rb
+++ b/spec/requests/api/v1/parties/create_spec.rb
@@ -20,26 +20,26 @@ RSpec.describe 'party creation endpoint' do
 
     it 'requires a valid request to have a valid player_id format and number' do
       # player_id missing
-      post "/api/v1/party/players?user_id=5", headers: {be_auth_key: ENV['be_auth_key']}
+      post "/api/v1/party/players?user_id=5", headers: {'HTTP_BE_AUTH_KEY' => ENV['be_auth_key'] }
       response_body = JSON.parse(response.body, symbolize_names: true)
       expect(response_body[:error]).to eq("a valid player_id parameter is required for this request")
 
       # player_id provided is not an ID
-      post "/api/v1/party/players?player_id=foobar&user_id=5", headers: {be_auth_key: ENV['be_auth_key']}
+      post "/api/v1/party/players?player_id=foobar&user_id=5", headers: {'HTTP_BE_AUTH_KEY' => ENV['be_auth_key'] }
       response_body = JSON.parse(response.body, symbolize_names: true)
       expect(response_body[:error]).to eq("player_id does not match the expected format")
 
       # player_id provided not found in database
       player = create(:player)
       Player.destroy(player.id)
-      post "/api/v1/party/players?player_id=#{player.id}&user_id=5", headers: {be_auth_key: ENV['be_auth_key']}
+      post "/api/v1/party/players?player_id=#{player.id}&user_id=5", headers: {'HTTP_BE_AUTH_KEY' => ENV['be_auth_key'] }
       response_body = JSON.parse(response.body, symbolize_names: true)
       expect(response_body[:error]).to eq("player_id provided was not found")
     end
 
     it 'refuses a request that lacks a user_id' do
       player = create(:player)
-      post "/api/v1/party/players?player_id=#{player.id}", headers: {be_auth_key: ENV['be_auth_key']}
+      post "/api/v1/party/players?player_id=#{player.id}", headers: {'HTTP_BE_AUTH_KEY' => ENV['be_auth_key'] }
       response_body = JSON.parse(response.body, symbolize_names: true)
       expect(response_body[:error]).to eq("user must be logged in to use this endpoint")
     end
@@ -53,14 +53,14 @@ RSpec.describe 'party creation endpoint' do
 
       # In the event a user does not have a party, we expect to create one
       expect(Party.where(user_id: 5).length).to eq(0)
-      post "/api/v1/party/players?player_id=#{player1.id}&user_id=5", headers: {be_auth_key: ENV['be_auth_key']}
+      post "/api/v1/party/players?player_id=#{player1.id}&user_id=5", headers: {'HTTP_BE_AUTH_KEY' => ENV['be_auth_key'] }
       # Now that our user has a party, we expect to be able to find it
       expect(Party.where(user_id: 5).length).to eq(1)
       party1 = Party.where(user_id: 5).first
-      post "/api/v1/party/players?player_id=#{player2.id}&user_id=5", headers: {be_auth_key: ENV['be_auth_key']}
+      post "/api/v1/party/players?player_id=#{player2.id}&user_id=5", headers: {'HTTP_BE_AUTH_KEY' => ENV['be_auth_key'] }
       # The party already exists, so after this request we expect 2 party player objects and 1 party object
       expect(Party.where(user_id: 5).length).to eq(1)
-      post "/api/v1/party/players?player_id=#{player3.id}&user_id=4", headers: {be_auth_key: ENV['be_auth_key']}
+      post "/api/v1/party/players?player_id=#{player3.id}&user_id=4", headers: {'HTTP_BE_AUTH_KEY' => ENV['be_auth_key'] }
       party2 = Party.where(user_id: 4).first
       expect(Party.where(user_id: 4).length).to eq 1
       expect(Party.where(user_id: 5).length).to eq 1
@@ -68,25 +68,25 @@ RSpec.describe 'party creation endpoint' do
       expect(PartyPlayer.where(party_id: party2.id).length).to eq 1
     end
 
-    it "does not add players redundantly to a party", headers: {be_auth_key: ENV['be_auth_key']} do
+    it "does not add players redundantly to a party" do
       player1 = create(:player)
       player2 = create(:player)
       player3 = create(:player)
 
-      post "/api/v1/party/players?player_id=#{player1.id}&user_id=5", headers: {be_auth_key: ENV['be_auth_key']}
+      post "/api/v1/party/players?player_id=#{player1.id}&user_id=5", headers: {'HTTP_BE_AUTH_KEY' => ENV['be_auth_key'] }
       party = Party.find_by(user_id: 5)
 
       expect(PartyPlayer.where(party_id: party.id).length).to eq 1
 
-      post "/api/v1/party/players?player_id=#{player1.id}&user_id=5", headers: {be_auth_key: ENV['be_auth_key']}
+      post "/api/v1/party/players?player_id=#{player1.id}&user_id=5", headers: {'HTTP_BE_AUTH_KEY' => ENV['be_auth_key'] }
 
       expect(PartyPlayer.where(party_id: party.id).length).to eq 1
 
-      post "/api/v1/party/players?player_id=#{player2.id}&user_id=5", headers: {be_auth_key: ENV['be_auth_key']}
+      post "/api/v1/party/players?player_id=#{player2.id}&user_id=5", headers: {'HTTP_BE_AUTH_KEY' => ENV['be_auth_key'] }
 
       expect(PartyPlayer.where(party_id: party.id).length).to eq 2
 
-      post "/api/v1/party/players?player_id=#{player2.id}&user_id=5", headers: {be_auth_key: ENV['be_auth_key']}
+      post "/api/v1/party/players?player_id=#{player2.id}&user_id=5", headers: {'HTTP_BE_AUTH_KEY' => ENV['be_auth_key'] }
 
       expect(PartyPlayer.where(party_id: party.id).length).to eq 2
     end
@@ -98,7 +98,7 @@ RSpec.describe 'party creation endpoint' do
       player2 = create(:player)
       player3 = create(:player)
       party = Party.create!(user_id: 5, name: "test name")
-      post "/api/v1/party/players?player_id=#{player1.id}&user_id=1", headers: {be_auth_key: ENV['be_auth_key']}
+      post "/api/v1/party/players?player_id=#{player1.id}&user_id=1", headers: {'HTTP_BE_AUTH_KEY' => ENV['be_auth_key'] }
       response_body = JSON.parse(response.body, symbolize_names: true)
       expect(response_body.class).to eq Hash
       expect(response_body[:data].class).to eq Hash


### PR DESCRIPTION
## Pull Request Template

### Function Checks:

```
[x] All tests passing
[x] Code runs locally
```

### Type of Change:

```
[ ] New Feature
[x] Bug fix
```

### Implementation/Fix Details:

```
Heroku threw errors in postman, found out the key being generated by `POST` requests with `be_auth_key` in the headers called is in fact `'HTTP_BE_AUTH_KEY'`. Our ApplicationController is expecting 'be_auth_key', so i changed that. 

Next error was uninitialized constant. Had to prepend `::` to the `Party.new` calls to override the name-spacing. 

Postman requests now work on localhost so long as you add the `be_auth_key` into the headers section
```

### Dummy check: Did this break anything else?

```
[ ] Yes
[x] No
```

### Testing changes:

```
[ ] No tests have been changed
[x] Some tests have been changed
```

### If 'yes' checked above, what tests had to be changed and how?

```
Had to change the headers in each test from 'be_auth_key' to 'HTTP_BE_AUTH_KEY'
```

### Final checklist:

```
[x] I have reviewed my code
[x] I have comments in my code for better understanding if needed
[x] I have tested my code
```
